### PR TITLE
Add capability to resolve relative documents

### DIFF
--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"github.com/getkin/kin-openapi/jsoninfo"
 )
 
 type Header struct {
@@ -12,6 +13,10 @@ type Header struct {
 
 	// Optional schema
 	Schema *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+func (value *Header) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
 }
 
 func (value *Header) Validate(c context.Context) error {

--- a/openapi3/swagger_loader_relative_refs_test.go
+++ b/openapi3/swagger_loader_relative_refs_test.go
@@ -716,3 +716,191 @@ const externalRequestResponseHeaderRefTemplate = `
         }
     }
 }`
+
+// Relative Schema Documents Tests
+var relativeDocRefsTestDataEntries = []refTestDataEntry{
+	{
+		name:            "SchemaRef",
+		contentTemplate: relativeSchemaDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.Schemas["TestSchema"].Value.Type)
+			require.Equal(t, "string", swagger.Components.Schemas["TestSchema"].Value.Type)
+		},
+	},
+	{
+		name:            "ResponseRef",
+		contentTemplate: relativeResponseDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.Responses["TestResponse"].Value.Description)
+			require.Equal(t, "description", swagger.Components.Responses["TestResponse"].Value.Description)
+		},
+	},
+	{
+		name:            "ParameterRef",
+		contentTemplate: relativeParameterDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.Parameters["TestParameter"].Value.Name)
+			require.Equal(t, "param", swagger.Components.Parameters["TestParameter"].Value.Name)
+			require.Equal(t, true, swagger.Components.Parameters["TestParameter"].Value.Required)
+		},
+	},
+	{
+		name:            "ExampleRef",
+		contentTemplate: relativeExampleDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.Examples["TestExample"].Value.Summary)
+			require.NotNil(t, "param", swagger.Components.Examples["TestExample"].Value.Value)
+			require.Equal(t, "An example", swagger.Components.Examples["TestExample"].Value.Summary)
+		},
+	},
+	{
+		name:            "RequestRef",
+		contentTemplate: relativeRequestDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.RequestBodies["TestRequestBody"].Value.Description)
+			require.Equal(t, "example request", swagger.Components.RequestBodies["TestRequestBody"].Value.Description)
+		},
+	},
+	{
+		name:            "HeaderRef",
+		contentTemplate: relativeHeaderDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.Headers["TestHeader"].Value.Description)
+			require.Equal(t, "description", swagger.Components.Headers["TestHeader"].Value.Description)
+		},
+	},
+	{
+		name:            "HeaderRef",
+		contentTemplate: relativeHeaderDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.Headers["TestHeader"].Value.Description)
+			require.Equal(t, "description", swagger.Components.Headers["TestHeader"].Value.Description)
+		},
+	},
+	{
+		name:            "SecuritySchemeRef",
+		contentTemplate: relativeSecuritySchemeDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Type)
+			require.NotNil(t, swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Scheme)
+			require.Equal(t, "http", swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Type)
+			require.Equal(t, "basic", swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Scheme)
+		},
+	},
+	{
+		name:            "PathRef",
+		contentTemplate: relativePathDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Paths["/pets"])
+			require.NotNil(t, swagger.Paths["/pets"].Get.Responses["200"])
+			require.NotNil(t, swagger.Paths["/pets"].Get.Responses["200"].Value.Content["application/json"])
+		},
+	},
+}
+
+func TestLoadSpecWithRelativeDocumentRefs(t *testing.T) {
+	for _, td := range relativeDocRefsTestDataEntries {
+		t.Logf("testcase '%s'", td.name)
+
+		spec := []byte(td.contentTemplate)
+		loader := openapi3.NewSwaggerLoader()
+		loader.IsExternalRefsAllowed = true
+		swagger, err := loader.LoadSwaggerFromDataWithPath(spec, &url.URL{Path: "testdata/"})
+		require.NoError(t, err)
+		td.testFunc(t, swagger)
+	}
+}
+
+const relativeSchemaDocsRefTemplate = `
+openapi: 3.0.0
+info: 
+  title: ""
+  version: "1.0"
+paths: {}
+components: 
+  schemas: 
+    TestSchema: 
+      $ref: relativeDocs/CustomTestSchema.yml
+`
+
+const relativeResponseDocsRefTemplate = `
+openapi: 3.0.0
+info: 
+  title: ""
+  version: "1.0"
+paths: {}
+components: 
+  responses: 
+    TestResponse: 
+      $ref: relativeDocs/CustomTestResponse.yml
+`
+
+const relativeParameterDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  parameters:
+    TestParameter: 
+      $ref: relativeDocs/CustomTestParameter.yml
+`
+
+const relativeExampleDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  examples:
+    TestExample:
+      $ref: relativeDocs/CustomTestExample.yml
+`
+
+const relativeRequestDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  requestBodies:
+    TestRequestBody:
+      $ref: relativeDocs/CustomTestRequestBody.yml
+`
+
+const relativeHeaderDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  headers:
+    TestHeader:
+      $ref: relativeDocs/CustomTestHeader.yml
+`
+
+const relativeSecuritySchemeDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  securitySchemes:
+    TestSecurityScheme:
+      $ref: relativeDocs/CustomTestSecurityScheme.yml
+`
+const relativePathDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "2.0"
+paths:
+  /pets:
+    $ref: relativeDocs/CustomTestPath.yml
+`
+

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -444,12 +444,3 @@ func TestLoadYamlFileWithExternalPathRef(t *testing.T) {
 	require.Equal(t, "string", swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
 }
 
-func TestLoadYamlFileWithExternalSchemaRefSingleComponent(t *testing.T) {
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
-	swagger, err := loader.LoadSwaggerFromFile("testdata/testrefsinglecomponent.openapi.yml")
-	require.NoError(t, err)
-
-	require.NotNil(t, swagger.Components.Responses["SomeResponse"])
-	require.Equal(t, "this is a single response definition", swagger.Components.Responses["SomeResponse"].Value.Description)
-}

--- a/openapi3/testdata/relativeDocs/CustomTestExample.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestExample.yml
@@ -1,0 +1,5 @@
+summary: An example
+value: |
+        {
+          "example": "hello"
+        }

--- a/openapi3/testdata/relativeDocs/CustomTestHeader.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestHeader.yml
@@ -1,0 +1,1 @@
+description: description

--- a/openapi3/testdata/relativeDocs/CustomTestParameter.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestParameter.yml
@@ -1,0 +1,3 @@
+name: param
+in: path
+required: true

--- a/openapi3/testdata/relativeDocs/CustomTestPath.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestPath.yml
@@ -1,0 +1,14 @@
+get:
+  operationId: findAllDefinitions
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              pets:
+                items:
+                  type: array
+                  properties:
+                    repository:
+                      name: string

--- a/openapi3/testdata/relativeDocs/CustomTestRequestBody.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestRequestBody.yml
@@ -1,0 +1,1 @@
+description: example request

--- a/openapi3/testdata/relativeDocs/CustomTestResponse.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestResponse.yml
@@ -1,0 +1,1 @@
+description: description

--- a/openapi3/testdata/relativeDocs/CustomTestSchema.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestSchema.yml
@@ -1,0 +1,1 @@
+type: string

--- a/openapi3/testdata/relativeDocs/CustomTestSecurityScheme.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestSecurityScheme.yml
@@ -1,0 +1,2 @@
+type: http
+scheme: basic


### PR DESCRIPTION
I refer to the thing we are doing here as "resolve relative documents" because that is how it is described here:

https://github.com/OAI/OpenAPI-Specification/blob/v3.1.0-dev/versions/3.0.2.md#relative-schema-document-example

which reminds me I should probably rename the function `loadSingleElementFromURI` introduced in the [proof of concept](https://github.com/getkin/kin-openapi/pull/81) to `LoadSingleDocumentFromURI` for consistency.