### PR TITLE
Add ExtensionProps field to ExternalDocs struct

### DIFF
--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -2,6 +2,8 @@ package openapi3
 
 // ExternalDocs is specified by OpenAPI/Swagger standard version 3.0.
 type ExternalDocs struct {
+	ExtensionProps
+
 	Description string `json:"description,omitempty"`
 	URL         string `json:"url,omitempty"`
 }


### PR DESCRIPTION
This PR modifies the `ExternalDocs` struct to support Extension Properties as defined in the [spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#external-documentation-object)